### PR TITLE
fix sync dispatch when change QUEUE_CONNECTION

### DIFF
--- a/src/SeoServiceProvider.php
+++ b/src/SeoServiceProvider.php
@@ -82,7 +82,7 @@ class SeoServiceProvider extends ServiceProvider
                         continue;
                     }
                     $jobClass = $modelConfig[$modelClassName]['job'];
-                    dispatch(new $jobClass($model));
+                    $jobClass::dispatch($model)->onConnection('sync');
                 }
             }
 


### PR DESCRIPTION
When I change `QUEUE_CONNECTION=database` in `.env`
`request()->get()` can't access any input.

that fix will force set queue connection is sync